### PR TITLE
Set the height to 100% on the checkbox rows to prevent a Chrome style…

### DIFF
--- a/src/components/StudentFilterForm.js
+++ b/src/components/StudentFilterForm.js
@@ -332,6 +332,7 @@ const CheckboxRow = styled.div`
   * + & {
     margin-top: 15px;
   }
+  height: 100%;
 `;
 
 const CheckboxColumnHeader = styled.div`


### PR DESCRIPTION
… bug

From my searching, this appears to be an introduced issue in Chrome which I think they have a fix for: https://bugs.chromium.org/p/chromium/issues/detail?id=927066 (tried the min-height: 0 workaround with no success).