### PR TITLE
Fixes to multiple date select component.

### DIFF
--- a/src/components/EditActivityForm.js
+++ b/src/components/EditActivityForm.js
@@ -261,7 +261,9 @@ class EditActivityForm extends Component {
                 <EventTimeInputRow>
                   {/* onChange={this.handleEventTimeChange} */}
                   <EventTimePicker value={eventTimes} handleDayClick={handleDayClick} />
-                  <EventAddButton onClick={this.handleAddEventClick} disabled={eventTimes.length === 0}>ADD EVENT</EventAddButton>
+                  <EventAddButton onClick={this.handleAddEventClick} disabled={eventTimes.length === 0}>
+                    ADD {eventTimes.length > 1 ? "EVENTS" : "EVENT"}
+                  </EventAddButton>
                 </EventTimeInputRow>
 
                 {events.length > 0 &&
@@ -407,7 +409,6 @@ const EventTimePicker = styled(MultipleDatePicker)`
   font-size: 12px;
   margin-right: 15px;
   font-family: "Open Sans";
-  font-style: italic;
   color: #4A4A4A;
   display: flex;
   justify-content: center;

--- a/src/components/MultipleDatePicker.js
+++ b/src/components/MultipleDatePicker.js
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { observable, action } from 'mobx';
 import { observer } from 'mobx-react';
 import { Calendar } from './Icons';
+import Tooltip from './Tooltip';
 
 @observer
 class MultipleDatePicker extends Component {
@@ -49,7 +50,15 @@ class MultipleDatePicker extends Component {
     )
   }
 
+  @action.bound renderDay(day) {
+    const { value } = this.props
+    const date = day.getDate()
+    const [first] = value
+    const Date = () => 
+      value.length === 1 && first.getTime() === day.getTime() ? <Tooltip text={"Select an additional occurrence or click done."}>{date}</Tooltip> : date
 
+    return <Date />
+  }
 
   @action.bound showCalendar(event) {
     event.preventDefault()
@@ -66,20 +75,24 @@ class MultipleDatePicker extends Component {
     const {
       showCalendar,
       closeCalendar,
-
       show,
       YearMonthForm,
-      current
+      current,
+      renderDay
     } = this
+
+    const daysSelected = value.length
+    const CalendarText = () =>
+      daysSelected === 0 ? <NoDateText> Add New Events to this Activity </NoDateText> : <DateSelectedText>{`${daysSelected} days selected`}</DateSelectedText>
 
     return (
       <Container>
-        <div className={className}>
-          Add New Events to this Activity
-          <Button onClick={showCalendar}>
+        <Button onClick={showCalendar}>
+          <div className={className}>
+            <CalendarText />
             <CalendarIcon />
-          </Button>
-        </div>
+          </div>
+        </Button>
         {show &&
           <CalendarItems>
             <DayPicker
@@ -88,6 +101,7 @@ class MultipleDatePicker extends Component {
               onDayClick={handleDayClick}
               modifiers={modifiers}
               modifiersStyles={modifiersStyles}
+              renderDay={renderDay}
               fixedWeeks
               captionElement={({ date, localeUtils }) =>
                 <YearMonthForm date={date} localeUtils={localeUtils} />
@@ -101,6 +115,14 @@ class MultipleDatePicker extends Component {
   }
 }
 export default MultipleDatePicker;
+
+const NoDateText = styled.div`
+  font-style: italic;
+`
+
+const DateSelectedText = styled.div`
+  font-weight: bold;
+`
 
 const modifiers = {
   weekends: {

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -23,10 +23,10 @@ const TooltipComponent = styled.div`
   .tooltiptext {
     display: flex;
     width: 140px;
-    background-color: black;
+    background-color: #F5633A;
     color: #FFF;
     text-align: center;
-    border-radius: 6px;
+    border-radius: 2px;
     padding: 3px;
     position: absolute;
     z-index: 1;
@@ -44,6 +44,6 @@ const TooltipComponent = styled.div`
     margin-left: -5px;
     border-width: 5px;
     border-style: solid;
-    border-color: black transparent transparent transparent;
+    border-color: #F5633A transparent transparent transparent;
   }
 `

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -1,0 +1,49 @@
+import React, { Component } from 'react';
+import styled from 'styled-components';
+
+class Tooltip extends Component {
+  render() {
+     const { children, text } = this.props
+     return (
+       <TooltipComponent> 
+         {children}
+         <span className="tooltiptext">
+           {text}
+         </span>
+       </TooltipComponent>
+     )
+  }
+}
+export default Tooltip;
+
+const TooltipComponent = styled.div`
+  position: relative;
+  display: inline-block;
+
+  .tooltiptext {
+    display: flex;
+    width: 140px;
+    background-color: black;
+    color: #FFF;
+    text-align: center;
+    border-radius: 6px;
+    padding: 3px;
+    position: absolute;
+    z-index: 1;
+    margin: -60px;
+    font-size: 12px;
+    font-style: italic;
+    top: 25%;
+  }
+
+  .tooltiptext::after {
+    content: " ";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: black transparent transparent transparent;
+  }
+`

--- a/src/screens/ImportData.js
+++ b/src/screens/ImportData.js
@@ -1,6 +1,6 @@
 import { action, computed, observable } from 'mobx';
 import { inject, observer } from 'mobx-react';
-import React, { Component, useState, useEffect, useCallback } from 'react';
+import React, { Component, useState, useEffect } from 'react';
 import { withRouter } from 'react-router-dom';
 import styled, {css} from 'styled-components';
 import sweetalert from 'sweetalert2';


### PR DESCRIPTION
Makes changes according to the following feedback: 

- Selecting anywhere in the date input should open the calendar (not just the calendar icon)
- Tooltip displays ’Select an additional occurrence or click done.’ after selecting the first date.
- After "Done" is selected, calendar closes, and input text changes to say "[n] days selected" (dark text, not italicized) and button is changed to "Add Events" (plural for multiple days, singular for single day)